### PR TITLE
Prevent warning during installing dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "stylelint": "^9.2.0"
   },
   "dependencies": {
-    "stylelint-order": "^0.8.1"
+    "stylelint-order": "*"
   },
   "scripts": {
     "test": "ava",


### PR DESCRIPTION
`warning "stylelint-config-concentric-order > stylelint-order@0.8.1" has incorrect peer dependency "stylelint@^8.0.0 || ^9.0.0".`
Looks like there no reason to lock version on 0.x