### PR TITLE
Inset should be before individual position properties

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,10 +5,6 @@ const groups = [
   [
     'display',
     'position',
-    'top',
-    'right',
-    'bottom',
-    'left',
     'inset',
     'inset-block',
     'inset-block-start',
@@ -16,6 +12,10 @@ const groups = [
     'inset-inline',
     'inset-inline-start',
     'inset-inline-end',
+    'top',
+    'right',
+    'bottom',
+    'left',
   ],
   ['float', 'clear'],
   [


### PR DESCRIPTION
As `inset` is a shorthand for individual position properties it should appear first so that you can override them separately, it also solves a conflict with `declaration-block-no-shorthand-property-overrides`