### PR TITLE
Update stylelint-order to version 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,10 +37,10 @@
     "ava": "^5.3.0",
     "lint-staged": "^13.0.0",
     "prettier": "^3.0.0",
-    "stylelint": "^15.0.0"
+    "stylelint": "^17.0.0"
   },
   "dependencies": {
-    "stylelint-order": "^6.0.0"
+    "stylelint-order": "^7.0.0"
   },
   "scripts": {
     "test": "ava",


### PR DESCRIPTION
I've just updated the stylelint-order to version 7, so we can use this package with stylelint 17